### PR TITLE
Add example of how to use email passord and email verification

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
 <script type="text/babel" src="js/register.js"></script>
 <script type="text/babel" src="js/recover.js"></script>
 <script type="text/babel" src="js/recoverwithemaillink.js"></script>
+<script type="text/babel" src="js/recoverwithemailpassword.js"></script>
 <script type="text/babel" src="js/account.js"></script>
 <script type="text/babel" src="js/logs.js"></script>
 <script type="text/babel" src="js/accountid.js"></script>

--- a/js/account.js
+++ b/js/account.js
@@ -81,6 +81,12 @@ class Account extends React.Component {
               onAccount={this.onAccount}
               onLog={this.props.onLog}
             />
+            <RecoverWithEmailPassword
+              config={this.props.config}
+              deviceKey={this.state.deviceKey}
+              onAccount={this.onAccount}
+              onLog={this.props.onLog}
+            />
           </span>
         }
         <fieldset>


### PR DESCRIPTION
### What
Add an email/password firebase component that provides an example of how to use email/password authentication and email verification to authenticate with a recoverysigner.

### Why
The demo client shows an example of how to authenticate using email links but Firebase also supports email authentication using password and supports email verification.

cc @stellar/vega-backend 