### PR TITLE
Use unpkg for stellar-sdk

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 <script src="https://www.gstatic.com/firebasejs/7.14.0/firebase-app.js"></script>
 <script src="https://www.gstatic.com/firebasejs/7.14.0/firebase-auth.js"></script>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/stellar-sdk/4.1.0/stellar-sdk.js"></script>
+<script src="https://unpkg.com/stellar-sdk@4.1.0/dist/stellar-sdk.min.js"></script>
 
 <script crossorigin src="https://unpkg.com/react@16/umd/react.development.js"></script>
 <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>


### PR DESCRIPTION
### What
Use minified stellar-sdk and unpkg for CDN.

### Why
May as well use the minified version, we don't need to dig into the details of the stellar SDK. I'm using the unpkg CDN for the other resources and may as well be consistent.